### PR TITLE
generate .tgz file

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           #Requires -Version "6.1"
           $osName = if ($IsWindows) { "win32" } elseif ($IsLinux) { "ubuntu" } else { "darwin" }
-          $artifactPath = "FBX-glTF-conv-${{ needs.get_release_info_job.outputs.version }}-$osName.zip"
+          $artifactPath = "FBX-glTF-conv-${{ needs.get_release_info_job.outputs.version }}-$osName.tgz"
           Write-Output "::set-output name=artifact_path::$artifactPath"
       - id: build
         name: Build
@@ -93,7 +93,7 @@ jobs:
         run: |
           #Requires -Version "6.1"
           $osName = if ($IsWindows) { "win32" } elseif ($IsLinux) { "ubuntu" } else { "darwin" }
-          $artifactPath = "FBX-glTF-conv-${{ needs.get_release_info_job.outputs.version }}-$osName.zip"
+          $artifactPath = "FBX-glTF-conv-${{ needs.get_release_info_job.outputs.version }}-$osName.tgz"
           Write-Output "::set-output name=artifact_path::$artifactPath"
       - id: build
         name: Build
@@ -127,7 +127,7 @@ jobs:
         shell: pwsh
         run: |
           #Requires -Version "6.1"
-          $artifactPath = "FBX-glTF-conv-${{ needs.get_release_info_job.outputs.version }}-types.zip"
+          $artifactPath = "FBX-glTF-conv-${{ needs.get_release_info_job.outputs.version }}-types.tgz"
           Write-Output "::set-output name=artifact_path::$artifactPath"
       - id: build
         name: Build

--- a/CI/build.sh
+++ b/CI/build.sh
@@ -242,7 +242,7 @@ build() {
     fi
     
     if [ -n "$ArtifactPath" ]; then
-        gzip -cr $cmakeInstallPrefix > $ArtifactPath
+        tar -czvf $ArtifactPath -C $cmakeInstallPrefix .
     fi
 }
 


### PR DESCRIPTION
As zip can not used on windows CI, so use tar to generate .tgz file.